### PR TITLE
adds glibc-utils so that gai.conf is properly populated enabling edge…

### DIFF
--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
@@ -34,7 +34,7 @@ SRC_URI += "\
 "
 
 DEPENDS = " libcap mosquitto mercurial-native curl"
-RDEPENDS_${PN} = " procps bash tar bzip2 rng-tools"
+RDEPENDS_${PN} = " procps bash tar bzip2 rng-tools glibc-utils"
 
 # Installed packages
 PACKAGES = "${PN} ${PN}-dbg"


### PR DESCRIPTION
… core to prefer IPV4 dns over IPV6