### PR TITLE
Look for update  certificate only when compiling in Developer mode

### DIFF
--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
@@ -30,7 +30,7 @@ SRC_URI = "git://github.com/ARMmbed/mbed-edge.git \
            file://0004-Removed-the-redundant-cmake-command.manual_patch"
 SRC_URI += "\
     ${@bb.utils.contains('MBED_EDGE_CORE_CONFIG_DEVELOPER_MODE','ON','file://mbed_cloud_dev_credentials.c','',d)} \
-    ${@bb.utils.contains('MBED_EDGE_CORE_CONFIG_FIRMWARE_UPDATE','ON','file://update_default_resources.c','',d)} \
+    ${@bb.utils.contains('MBED_EDGE_CORE_CONFIG_DEVELOPER_MODE','ON','file://update_default_resources.c','',d)} \
 "
 
 DEPENDS = " libcap mosquitto mercurial-native curl"


### PR DESCRIPTION
In our customer facing documentation [here](https://developer.pelion.com/docs/device-management-edge/2.1/quick-start/yocto-quick-start.html), its mandatory to provide the update certificate. ~So we don't have to support the use case where we allow a dev build without FOTA.~

This also solves the issue where if user is building FACTORY_MODE with FIRMWARE_UPDATE, the user don't have to provide the update certificate.

1. Dev without fota - ~Not~ supported, as FIRMWARE_UPDATE is  turned off by default
2. Dev with fota -  supported, user will have to add bitbake flag to local.conf at build time. Created the PR to update docs - https://github.com/PelionIoT/pelion-dm-edge-docs/pull/108 
3. factory without fota - supported
4. factory with fota - supported