### PR TITLE
Allow PE Yocto users to modify the mbed-cloud-client config options

### DIFF
--- a/recipes-connectivity/mbed-edge-core/files/mbed_cloud_client_user_config.h
+++ b/recipes-connectivity/mbed-edge-core/files/mbed_cloud_client_user_config.h
@@ -1,6 +1,6 @@
 /*
  * ----------------------------------------------------------------------------
- * Copyright 2021 ARM Ltd.
+ * Copyright 2018-2021 ARM Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/recipes-connectivity/mbed-edge-core/files/mbed_cloud_client_user_config.h
+++ b/recipes-connectivity/mbed-edge-core/files/mbed_cloud_client_user_config.h
@@ -1,6 +1,6 @@
 /*
  * ----------------------------------------------------------------------------
- * Copyright 2018 ARM Ltd.
+ * Copyright 2021 ARM Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/recipes-connectivity/mbed-edge-core/files/mbed_cloud_client_user_config.h
+++ b/recipes-connectivity/mbed-edge-core/files/mbed_cloud_client_user_config.h
@@ -1,0 +1,44 @@
+/*
+ * ----------------------------------------------------------------------------
+ * Copyright 2018 ARM Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+
+/*
+ * Minimal configuration for using mbed-cloud-client
+ */
+
+#ifndef MBED_CLOUD_CLIENT_USER_CONFIG_H
+#define MBED_CLOUD_CLIENT_USER_CONFIG_H
+
+#define MBED_CLOUD_CLIENT_SUPPORT_CLOUD
+#define MBED_CLOUD_CLIENT_ENDPOINT_TYPE          "MBED_GW"
+#define MBED_CLOUD_CLIENT_TRANSPORT_MODE_TCP
+#define MBED_CLOUD_CLIENT_LIFETIME               1800
+
+#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE       1024
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT       0
+#define SN_COAP_DISABLE_RESENDINGS               1
+
+/* set download buffer size in bytes (min. 1024 bytes) */
+#define MBED_CLOUD_CLIENT_UPDATE_BUFFER          (2 * 1024 * 1024)
+
+/* set the TCP KEEPALIVE values */
+#define MBED_CLIENT_TCP_KEEPALIVE_INTERVAL 60
+#define MBED_CLIENT_TCP_KEEPALIVE_TIME 60
+
+#endif /* MBED_CLIENT_USER_CONFIG_H */

--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
@@ -15,6 +15,7 @@ SRC_URI = "git://github.com/ARMmbed/mbed-edge.git \
            file://edge-core.service \
            file://edge-core.logrotate \
            file://toolchain.cmake \
+           file://mbed_cloud_client_user_config.h \
            file://0001-disable-Doxygen.patch \
            file://0002-fix-libevent-build-with-CMake-in-Yocto.patch \
            file://0003-fix_libwebsockets_nondebug.manual_patch \
@@ -51,6 +52,7 @@ EXTRA_OECMAKE += " \
     -DTARGET_TOOLCHAIN=yocto \
     -DMBED_CONF_MBED_TRACE_ENABLE=1 \
     -DTARGET_CONFIG_ROOT=${WORKDIR} \
+    -DCLOUD_CLIENT_CONFIG=${WORKDIR}/mbed_cloud_client_user_config.h \
     -DTRACE_LEVEL=${MBED_EDGE_CORE_CONFIG_TRACE_LEVEL} \
     -DFIRMWARE_UPDATE=${MBED_EDGE_CORE_CONFIG_FIRMWARE_UPDATE} \
     -DMBED_CLOUD_CLIENT_CURL_DYNAMIC_LINK=${MBED_EDGE_CORE_CONFIG_CURL_DYNAMIC_LINK} \


### PR DESCRIPTION
Customer has requested a way to modify the keep alive interval through Yocto recipe. Reduced the default lifetime (registration message interval) from 1 hour to 30 mins.