### PR TITLE
RPi: Update scripts revised as per 2.2 release and UC hub documentation

### DIFF
--- a/recipes-connectivity/mbed-edge-core/files/rpi3/arm_update_activate.sh
+++ b/recipes-connectivity/mbed-edge-core/files/rpi3/arm_update_activate.sh
@@ -11,24 +11,35 @@
 #
 . /wigwag/mbed/arm_update_cmdline.sh
 
-echo "-------------------- Executing activate.sh -------------------------"
+set -x
+
+echo "Info: Executing arm_update_activate.sh"
+
+# store the header into partition which survies factory reset
 mkdir -p /userdata/extended
-# copy header to store
-VALUE=$(cp $HEADER /userdata/extended/header.bin)
+if ! cp $HEADER /userdata/extended/header.bin; then 
+    echo "Error: Failed to store the header!"
+    exit 8
+fi
 
+# backup the system and journal logs
 mkdir -p /userdata/.logs-before-upgrade
-cp -R /wigwag/log/* /userdata/.logs-before-upgrade/
+cp -R /var/log/* /userdata/.logs-before-upgrade/
 
-# save version checksum
+# save version file checksum
 md5sum /wigwag/etc/versions.json > /userdata/mbed/version_checksum.md5
 
-systemctl stop maestro
-systemctl start maestro
-
+# save the firmware image to /upgrades partition
+# /upgrades is where the Pelion Edge's upgrade utility expects the image to be
+# checkout out https://github.com/PelionIoT/scripts-pelion-edge to learn more about the update image packaging
 mv $FIRMWARE /upgrades/firmware.tar.gz
-tar -xzf /upgrades/firmware.tar.gz -C /upgrades/
-systemctl start deviceos-wd
-reboot
-echo "-------------------- Finished activate.sh -------------------------"
-exit $VALUE
+if ! tar -xzf /upgrades/firmware.tar.gz -C /upgrades/; then
+    echo "Error: Image copy failed!"
+    exit 5
+fi
 
+# go to middle boot and try applying the update
+reboot
+
+echo "Info: Exiting arm_update_activate.sh"
+exit 0

--- a/recipes-connectivity/mbed-edge-core/files/rpi3/arm_update_active_details.sh
+++ b/recipes-connectivity/mbed-edge-core/files/rpi3/arm_update_active_details.sh
@@ -9,15 +9,27 @@
 # SIZE
 #
 . /wigwag/mbed/arm_update_cmdline.sh
-# copy stored header to expected location
-echo "-------------------- Executing active_details.sh -------------------------"
 
+set -x
+
+echo "Info: Executing arm_update_active_details.sh"
+
+# software version file after the firmware updated is expected to be changed
+# thus for successful firmware update md5sum check should fail
 if md5sum -c /userdata/mbed/version_checksum.md5 | grep -q 'FAILED'; then
-  VALUE=$(cp /userdata/extended/header.bin $HEADER)
-  echo $HEADER
-  echo "-------------------- Build version changed, returning header --------------------";
-  exit $VALUE
+
+    # copy stored header to expected location
+    if ! cp /userdata/extended/header.bin $HEADER; then
+        echo "Error: No active firmware header found!"
+        exit 9
+    fi
+
+    echo "Info: Firmware update successful!";
+    exit 0
+
 else
-  echo "-------------------- Build version same, returning null --------------------";
-  exit
+
+    echo "Error: Firmware update failed, version file did not update!";
+    exit 8
+
 fi

--- a/recipes-connectivity/mbed-edge-core/files/rpi3/arm_update_cmdline.sh
+++ b/recipes-connectivity/mbed-edge-core/files/rpi3/arm_update_cmdline.sh
@@ -43,4 +43,3 @@ done
 # echo "location: ${LOCATION}"
 # echo "offset:   ${OFFSET}"
 # echo "size:     ${SIZE}"
-


### PR DESCRIPTION
Updated the FOTA scripts used on RPi platform.
Exit code used as per the doc - https://developer.pelion.com/docs/device-management/current/porting/porting-the-device-management-update-client-to-linux-systems.html 

Testing - Not yet verified. 