### PR TITLE
.gitignore cert files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ GRTAGS
 GSYMS
 GTAGS
 
+# Do not track the cert files by default to prevent chances of anyone slipping real certs here
+recipes-connectivity/mbed-edge-core/files/mbed_cloud_dev_credentials.c
+recipes-connectivity/mbed-edge-core/files/update_default_resources.c


### PR DESCRIPTION
Do not track the certificate files in order to avoid any accidental slips to a git push.