### PR TITLE
Remove old update client scripts

### DIFF
--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core-imx8mmevk.bb
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core-imx8mmevk.bb
@@ -34,8 +34,5 @@ do_configure_prepend() {
 
 
 do_install_append() {
-    install -m 755 "${SCRIPT_DIR}/arm_update_cmdline.sh"                  "${D}/wigwag/mbed"
-    install -m 755 "${SCRIPT_DIR}/yocto_generic/arm_update_activate.sh"       "${D}/wigwag/mbed"
-    install -m 755 "${SCRIPT_DIR}/yocto_generic/arm_update_active_details.sh" "${D}/wigwag/mbed"
     install -m 755 "${WORKDIR}/deploy_ostree_delta_update.sh" "${D}/wigwag/mbed"
 }

--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core-uz.bb
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core-uz.bb
@@ -32,8 +32,5 @@ do_configure_prepend() {
 }
 
 do_install_append() {
-    install -m 755 "${SCRIPT_DIR}/arm_update_cmdline.sh"                  "${D}/wigwag/mbed"
-    install -m 755 "${SCRIPT_DIR}/yocto_generic/arm_update_activate.sh"       "${D}/wigwag/mbed"
-    install -m 755 "${SCRIPT_DIR}/yocto_generic/arm_update_active_details.sh" "${D}/wigwag/mbed"
     install -m 755 "${WORKDIR}/deploy_ostree_delta_update.sh" "${D}/wigwag/mbed"
 }


### PR DESCRIPTION
For LmP ostree script is used instead.

This is against dev branch as original (#48) was accidentally made against master.

cc: @JanneKiiskila @petedyerarm 