### PR TITLE
Refactor target.cmake and add curl for RPi

### DIFF
--- a/recipes-connectivity/mbed-edge-core/files/mx8mm/target.cmake
+++ b/recipes-connectivity/mbed-edge-core/files/mx8mm/target.cmake
@@ -8,36 +8,8 @@ SET (BIND_TO_ALL_INTERFACES 0)
 SET (PAL_UPDATE_FIRMWARE_DIR "\"/mnt/cache/firmware\"")
 SET (ARM_UC_SOCKET_TIMEOUT_MS 300000)
 
-if (${FOTA_ENABLE})
-  add_definitions(
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_HEADER_FILENAME="/userdata/fota_fw_metadata"
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_UPDATE_STORAGE_FILENAME="/userdata/fota_candidate"
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_CANDIDATE_FILENAME="/userdata/fota_raw_candidate"
-  )
-endif()
-
-# When PARSEC_TPM_SE_SUPPORT is enabled, most likely you are using PSA trusted
-# storage rather than default ESFS to save the provisioning data. In that case, these
-# macros are don't care. To control the psa storage file location, please modify the
-# config/psa_storage_user_config.h.
-SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/userdata/mbed/mcc_config\"")
-SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/userdata/mbed/mcc_config\"")
-
 if (${FIRMWARE_UPDATE})
   SET (MBED_CLOUD_CLIENT_UPDATE_STORAGE ARM_UCP_LINUX_YOCTO_GENERIC)
 endif()
 
-if (${FOTA_ENABLE})
-  SET (MBED_CLOUD_CLIENT_MIDDLEWARE curl)
-  SET (PLATFORM_TARGET Yocto_Generic_YoctoLinux_mbedtls)
-endif()
-
-if(${PARSEC_TPM_SE_SUPPORT})
-  SET (MBED_CLOUD_CLIENT_MIDDLEWARE trusted_storage mbedtls parsec_se_driver)
-  SET (PLATFORM_TARGET Yocto_Generic_YoctoLinux_mbedtls)
-  SET (MBED_CLOUD_CLIENT_OS Linux_Yocto_v2.2)
-  SET (MBED_CLOUD_CLIENT_SDK )
-  SET (MBED_CLOUD_CLIENT_TOOLCHAIN )
-  SET (MBED_CLOUD_CLIENT_BUILD_SYS_MIN_VER 2)
-  SET (MBED_CLOUD_CLIENT_NATIVE_SDK False)
-endif()
+include(${TARGET_CONFIG_ROOT}/target-default.cmake)

--- a/recipes-connectivity/mbed-edge-core/files/rpi3/target.cmake
+++ b/recipes-connectivity/mbed-edge-core/files/rpi3/target.cmake
@@ -8,31 +8,8 @@ SET (BIND_TO_ALL_INTERFACES 0)
 SET (PAL_UPDATE_FIRMWARE_DIR "\"/upgrades\"")
 SET (ARM_UC_SOCKET_TIMEOUT_MS 300000)
 
-if (${FOTA_ENABLE})
-  add_definitions(
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_HEADER_FILENAME="/userdata/fota_fw_metadata"
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_UPDATE_STORAGE_FILENAME="/userdata/fota_candidate"
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_CANDIDATE_FILENAME="/userdata/fota_raw_candidate"
-  )
-endif()
-
-# When PARSEC_TPM_SE_SUPPORT is enabled, most likely you are using PSA trusted
-# storage rather than default ESFS to save the provisioning data. In that case, these
-# macros are irrelevant. To control the psa storage file location, please modify the
-# config/psa_storage_user_config.h.
-SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/userdata/mbed/mcc_config\"")
-SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/userdata/mbed/mcc_config\"")
-
 if (${FIRMWARE_UPDATE})
   SET (MBED_CLOUD_CLIENT_UPDATE_STORAGE ARM_UCP_LINUX_YOCTO_RPI)
 endif()
 
-if(${PARSEC_TPM_SE_SUPPORT})
-  SET (MBED_CLOUD_CLIENT_MIDDLEWARE trusted_storage mbedtls parsec_se_driver)
-  SET (PLATFORM_TARGET Yocto_Generic_YoctoLinux_mbedtls)
-  SET (MBED_CLOUD_CLIENT_OS Linux_Yocto_v2.2)
-  SET (MBED_CLOUD_CLIENT_SDK )
-  SET (MBED_CLOUD_CLIENT_TOOLCHAIN )
-  SET (MBED_CLOUD_CLIENT_BUILD_SYS_MIN_VER 2)
-  SET (MBED_CLOUD_CLIENT_NATIVE_SDK False)
-endif()
+include(${TARGET_CONFIG_ROOT}/target-default.cmake)

--- a/recipes-connectivity/mbed-edge-core/files/target-default.cmake
+++ b/recipes-connectivity/mbed-edge-core/files/target-default.cmake
@@ -1,0 +1,27 @@
+if (${FOTA_ENABLE})
+  add_definitions(
+      -DMBED_CLOUD_CLIENT_FOTA_LINUX_HEADER_FILENAME="/userdata/fota_fw_metadata"
+      -DMBED_CLOUD_CLIENT_FOTA_LINUX_UPDATE_STORAGE_FILENAME="/userdata/fota_candidate"
+      -DMBED_CLOUD_CLIENT_FOTA_LINUX_CANDIDATE_FILENAME="/userdata/fota_raw_candidate"
+  )
+
+  SET (MBED_CLOUD_CLIENT_MIDDLEWARE curl)
+  SET (PLATFORM_TARGET Yocto_Generic_YoctoLinux_mbedtls)
+endif()
+
+# When PARSEC_TPM_SE_SUPPORT is enabled, most likely you are using PSA trusted
+# storage rather than default ESFS to save the provisioning data. In that case, these
+# macros are irrelevant. To control the psa storage file location, please modify the
+# config/psa_storage_user_config.h.
+SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/userdata/mbed/mcc_config\"")
+SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/userdata/mbed/mcc_config\"")
+
+if(${PARSEC_TPM_SE_SUPPORT})
+  SET (MBED_CLOUD_CLIENT_MIDDLEWARE trusted_storage mbedtls parsec_se_driver)
+  SET (PLATFORM_TARGET Yocto_Generic_YoctoLinux_mbedtls)
+  SET (MBED_CLOUD_CLIENT_OS Linux_Yocto_v2.2)
+  SET (MBED_CLOUD_CLIENT_SDK )
+  SET (MBED_CLOUD_CLIENT_TOOLCHAIN )
+  SET (MBED_CLOUD_CLIENT_BUILD_SYS_MIN_VER 2)
+  SET (MBED_CLOUD_CLIENT_NATIVE_SDK False)
+endif()

--- a/recipes-connectivity/mbed-edge-core/files/uz/target.cmake
+++ b/recipes-connectivity/mbed-edge-core/files/uz/target.cmake
@@ -8,37 +8,8 @@ SET (BIND_TO_ALL_INTERFACES 0)
 SET (PAL_UPDATE_FIRMWARE_DIR "\"/mnt/cache/firmware\"")
 SET (ARM_UC_SOCKET_TIMEOUT_MS 300000)
 
-if (${FOTA_ENABLE})
-  add_definitions(
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_HEADER_FILENAME="/userdata/fota_fw_metadata"
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_UPDATE_STORAGE_FILENAME="/userdata/fota_candidate"
-      -DMBED_CLOUD_CLIENT_FOTA_LINUX_CANDIDATE_FILENAME="/userdata/fota_raw_candidate"
-  )
-endif()
-
-# When PARSEC_TPM_SE_SUPPORT is enabled, most likely you are using PSA trusted
-# storage rather than default ESFS to save the provisioning data. In that case, these
-# macros are irrelevant. To control the psa storage file location, please modify the
-# config/psa_storage_user_config.h.
-SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/userdata/mbed/mcc_config\"")
-SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/userdata/mbed/mcc_config\"")
-
 if (${FIRMWARE_UPDATE})
   SET (MBED_CLOUD_CLIENT_UPDATE_STORAGE ARM_UCP_LINUX_YOCTO_GENERIC)
 endif()
 
-if (${FOTA_ENABLE})
-  SET (MBED_CLOUD_CLIENT_MIDDLEWARE curl)
-  SET (PLATFORM_TARGET Yocto_Generic_YoctoLinux_mbedtls)
-endif()
-
-if(${PARSEC_TPM_SE_SUPPORT})
-  SET (MBED_CLOUD_CLIENT_MIDDLEWARE trusted_storage mbedtls parsec_se_driver)
-  SET (PLATFORM_TARGET Yocto_Generic_YoctoLinux_mbedtls)
-  SET (MBED_CLOUD_CLIENT_OS Linux_Yocto_v2.2)
-  SET (MBED_CLOUD_CLIENT_SDK )
-  SET (MBED_CLOUD_CLIENT_TOOLCHAIN )
-  SET (MBED_CLOUD_CLIENT_BUILD_SYS_MIN_VER 2)
-  SET (MBED_CLOUD_CLIENT_NATIVE_SDK False)
-endif()
-
+include(${TARGET_CONFIG_ROOT}/target-default.cmake)

--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core-mx8mm.bb
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core-mx8mm.bb
@@ -17,6 +17,7 @@ RPROVIDES_${PN} += " virtual/mbed-edge-core virtual/mbed-edge-core-dbg "
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/mbed-mx8mm:"
 SRC_URI += "file://target.cmake \
+            file://target-default.cmake \
             file://sotp_fs_mx8mm_yocto.h \
             file://deploy_ostree_delta_update.sh \
             file://0006-fota-callback.patch \

--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core-rpi3.bb
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core-rpi3.bb
@@ -17,6 +17,7 @@ RPROVIDES_${PN} += " virtual/mbed-edge-core virtual/mbed-edge-core-dbg "
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/rpi3:"
 SRC_URI += "file://target.cmake \
+            file://target-default.cmake \
             file://sotp_fs_rpi3_yocto.h \
             file://deploy_ostree_delta_update.sh \
             file://0006-fota-callback.patch \

--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core-uz.bb
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core-uz.bb
@@ -17,6 +17,7 @@ RPROVIDES_${PN} += " virtual/mbed-edge-core virtual/mbed-edge-core-dbg "
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/mbed-uz:"
 SRC_URI += "file://target.cmake \
+            file://target-default.cmake \
             file://sotp_fs_uz_yocto.h \
             file://deploy_ostree_delta_update.sh \
             file://0006-fota-callback.patch \


### PR DESCRIPTION
A default target.cmake common to all targets.

Also added missing definitions in RPi config:
```
  SET (MBED_CLOUD_CLIENT_MIDDLEWARE curl)
  SET (PLATFORM_TARGET Yocto_Generic_YoctoLinux_mbedtls)
```