### PR TITLE
Create and publish generic PE dev builds with BYOC_MODE

### DIFF
--- a/recipes-connectivity/mbed-edge-core/files/edge-core-byoc.service
+++ b/recipes-connectivity/mbed-edge-core/files/edge-core-byoc.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Edge Core
+After=systemd-networkd-wait-online.service
+
+[Service]
+Restart=always
+RestartSec=5s
+ExecStartPre=mkdir -p /userdata/mbed
+ExecStartPre=chown developer -R /userdata/mbed
+ExecStart=/wigwag/system/bin/launch-byoc-edge-core.sh
+
+[Install]
+RequiredBy=network.target

--- a/recipes-connectivity/mbed-edge-core/files/launch-byoc-edge-core.sh
+++ b/recipes-connectivity/mbed-edge-core/files/launch-byoc-edge-core.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2020, Arm Limited and affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+set -e
+
+CREDENTIALS_DIR="/userdata/mbed"
+DEVELOPER_CERTIFICATE="${CREDENTIALS_DIR}/mbed_cloud_dev_credentials.c"
+UPDATE_CERTIFICATE="${CREDENTIALS_DIR}/update_default_resources.c"
+DEV_CBOR="${CREDENTIALS_DIR}/mbed_cloud_dev_credentials.cbor"
+
+EDGE_CORE="/wigwag/mbed/edge-core"
+EDGE_TOOL_CMD="/wigwag/mbed/edge-tool/edge_tool.py convert-dev-cert \
+--development-certificate ${DEVELOPER_CERTIFICATE} \
+--cbor ${DEV_CBOR} \
+--update-resource ${UPDATE_CERTIFICATE}"
+
+if [[ ! -f "$DEV_CBOR" ]]; then
+    echo "CBOR file not found, checking if developer and update certificates are available..."
+    if [[ -f "$DEVELOPER_CERTIFICATE" ]] && [[ -f "$UPDATE_CERTIFICATE" ]]; then
+        echo "Found developer and update certificates. Generating CBOR using cmd - $EDGE_TOOL_CMD"
+        $EDGE_TOOL_CMD
+    else
+        echo "Developer or update certificate not found at $CREDENTIALS_DIR. Device is not configured for Pelion Device Management!"
+        exit 1
+    fi
+fi
+
+echo "Found CBOR formatted credentials at $DEV_CBOR. Starting edge-core..."
+
+exec $EDGE_CORE \
+--cbor-conf $DEV_CBOR \
+--http-port 9101

--- a/recipes-connectivity/mbed-edge-core/files/launch-byoc-edge-core.sh
+++ b/recipes-connectivity/mbed-edge-core/files/launch-byoc-edge-core.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, Arm Limited and affiliates.
+# Copyright (c) 2021, Pelion Ltd.
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
@@ -32,6 +32,7 @@ DEPENDS = " libcap mosquitto mercurial-native curl python3-native python3-pip-na
 DEPENDS += "${@ 'parsec-se-driver' if d.getVar('MBED_EDGE_CORE_CONFIG_PARSEC_TPM_SE_SUPPORT') == 'ON' else ' '}"
 
 RDEPENDS_${PN} = " procps bash tar bzip2 rng-tools glibc-utils"
+RDEPENDS_${PN} += "${@ 'edge-tool' if d.getVar('MBED_EDGE_CORE_CONFIG_BYOC_MODE') == 'ON' else ' '}"
 
 # Installed packages
 PACKAGES = "${PN} ${PN}-dbg"

--- a/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-connectivity/mbed-edge-core/mbed-edge-core.inc
@@ -12,7 +12,6 @@ RM_WORK_EXCLUDE += "${PN}"
 
 SRC_URI = "git://github.com/ARMmbed/mbed-edge.git \
            file://edge-core.init \
-           file://edge-core.service \
            file://edge-core.logrotate \
            file://toolchain.cmake \
            file://mbed_cloud_client_user_config.h \
@@ -24,6 +23,9 @@ SRC_URI = "git://github.com/ARMmbed/mbed-edge.git \
 SRC_URI += "\
     ${@bb.utils.contains('MBED_EDGE_CORE_CONFIG_DEVELOPER_MODE','ON','file://mbed_cloud_dev_credentials.c','',d)} \
     ${@bb.utils.contains('MBED_EDGE_CORE_CONFIG_DEVELOPER_MODE','ON','file://update_default_resources.c','',d)} \
+    ${@bb.utils.contains('MBED_EDGE_CORE_CONFIG_BYOC_MODE','OFF','file://edge-core.service','',d)} \
+    ${@bb.utils.contains('MBED_EDGE_CORE_CONFIG_BYOC_MODE','ON','file://edge-core-byoc.service','',d)} \
+    ${@bb.utils.contains('MBED_EDGE_CORE_CONFIG_BYOC_MODE','ON','file://launch-byoc-edge-core.sh','',d)} \
 "
 
 DEPENDS = " libcap mosquitto mercurial-native curl python3-native python3-pip-native python3 python3-setuptools-native python3-setuptools-scm"
@@ -40,6 +42,8 @@ FILES_${PN} += "/wigwag \
 
 FILES_${PN}-dbg += "/wigwag/mbed/debug \
                     /usr/src/debug/mbed-edge"
+
+wbindir= "/wigwag/system/bin"
 
 S = "${WORKDIR}/git"
 
@@ -105,7 +109,14 @@ do_install() {
     install -m 755 "${WORKDIR}/edge-core.init" "${D}/etc/init.d/${INITSCRIPT_NAME}"
 
     install -d "${D}${systemd_system_unitdir}"
-    install -m 755 "${WORKDIR}/edge-core.service" "${D}${systemd_system_unitdir}/edge-core.service"
+
+    if [ "${MBED_EDGE_CORE_CONFIG_BYOC_MODE}" = "ON" ]; then
+        install -d "${D}${wbindir}"
+        install -m 755 "${WORKDIR}/edge-core-byoc.service" "${D}${systemd_system_unitdir}/edge-core.service"
+        install -m 755 "${WORKDIR}/launch-byoc-edge-core.sh" "${D}${wbindir}/"
+    else
+        install -m 755 "${WORKDIR}/edge-core.service" "${D}${systemd_system_unitdir}/edge-core.service"
+    fi
 
     install -d "${D}/wigwag/mbed"
     install "${WORKDIR}/build/bin/edge-core" "${D}/wigwag/mbed"


### PR DESCRIPTION
When compiled with BYOC_MODE=ON, it will allow you to create a generic Pelion Edge LmP dev builds for your targets i.e., image is not associated to a Pelion DM account or a developer certificate. This looks similar to FACTORY_MODE but with this, you will not have to provision the gateway using pep or FCU/FCC tool. Once the gateway is booted, you will have to place the developer and update certificate C files at `/userdata/mbed`. The launch script will detect that and pass it through `edge-tool` to generate a CBOR fomatted credential object which will then be passed to `edge-core` on start. **In short, moved the injection of developer certificate from build time to runtime.** 

It also enable you to publish and distribute these images to other users who can use their own certificate without having to setup their own build environment. 

Added different service unit file for this mode and a launch script to go with it.

I have manually tested this flow. This PR should be merged after edge-tool has been added - #58.