### PR TITLE
Allow for delta updates generated from scratch.

### DIFF
--- a/recipes-connectivity/mbed-edge-core/files/deploy_ostree_delta_update.sh
+++ b/recipes-connectivity/mbed-edge-core/files/deploy_ostree_delta_update.sh
@@ -50,15 +50,9 @@ to_sha=$(grep To-sha /tmp/$$/metadata | cut -d":" -f2)
 # Clear exit on error
 set +e
 
-if [ ${from_sha} = "delta_created_from_scratch" ]; then
-    # The from_sha specified indicated that this is a full update generated
-    # from scratch, so allow the update to proceed.
-    RESULT=0
-else
-    # check that the ostree repo deployed on the device contains the base sha.
-    ostree ls $from_sha > /dev/null 2>&1
-    RESULT=$?
-fi
+# check that the ostree repo deployed on the device contains the base sha.
+ostree ls $from_sha > /dev/null 2>&1
+RESULT=$?
 
 if [ $RESULT -eq 0 ]; then
 


### PR DESCRIPTION
Removed the test against the pre-defined string.

This is not required to apply the updates generated from scratch and should be removed.