### PR TITLE
Restrict access to mbed configuration, setting permissions to 700 with owner=root

### DIFF
--- a/recipes-connectivity/mbed-edge-core/files/edge-core-byoc.service
+++ b/recipes-connectivity/mbed-edge-core/files/edge-core-byoc.service
@@ -5,8 +5,7 @@ After=systemd-networkd-wait-online.service
 [Service]
 Restart=always
 RestartSec=5s
-ExecStartPre=mkdir -p /userdata/mbed
-ExecStartPre=chown developer -R /userdata/mbed
+ExecStartPre=mkdir -m640 -p /userdata/mbed
 ExecStart=/wigwag/system/bin/launch-byoc-edge-core.sh
 
 [Install]

--- a/recipes-connectivity/mbed-edge-core/files/edge-core-byoc.service
+++ b/recipes-connectivity/mbed-edge-core/files/edge-core-byoc.service
@@ -5,7 +5,7 @@ After=systemd-networkd-wait-online.service
 [Service]
 Restart=always
 RestartSec=5s
-ExecStartPre=mkdir -m640 -p /userdata/mbed
+ExecStartPre=mkdir -m700 -p /userdata/mbed
 ExecStart=/wigwag/system/bin/launch-byoc-edge-core.sh
 
 [Install]

--- a/recipes-connectivity/mbed-edge-core/files/edge-core.service
+++ b/recipes-connectivity/mbed-edge-core/files/edge-core.service
@@ -5,7 +5,7 @@ After=systemd-networkd-wait-online.service
 [Service]
 Restart=always
 RestartSec=5s
-ExecStartPre=mkdir -m640 -p /userdata/mbed
+ExecStartPre=mkdir -m700 -p /userdata/mbed
 ExecStart=/wigwag/mbed/edge-core  --http-port 9101
 
 [Install]

--- a/recipes-connectivity/mbed-edge-core/files/edge-core.service
+++ b/recipes-connectivity/mbed-edge-core/files/edge-core.service
@@ -5,8 +5,7 @@ After=systemd-networkd-wait-online.service
 [Service]
 Restart=always
 RestartSec=5s
-ExecStartPre=mkdir -p /userdata/mbed
-ExecStartPre=chown developer -R /userdata/mbed
+ExecStartPre=mkdir -m640 -p /userdata/mbed
 ExecStart=/wigwag/mbed/edge-core  --http-port 9101
 
 [Install]


### PR DESCRIPTION
Mbed configuration by defualt should only be accessible by root user with read/write
permissions. Allow users in root group to read.